### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,14 @@
 # This workflow will do a clean install of the dependencies and run tests across different versions
 #
 # Replace <track> with the track name
-# Replace <image-name> with an image to run the jobs on
-# Replace <action to setup tooling> with a github action to setup tooling on the image
-# Replace <install dependencies> with a cli command to install the dependencies
+# Replace <image-name> with an image to@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"} run the jobs on
+# Replace <action@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-reposito@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"}ry"} to setup@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"} tooling>@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"} with a github action to setup tooling on the image
+# Replace <install dependencies> with a cli command to@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"} install the dependencies
 #
-# Find Github Actions to setup tooling here:
-# - https://github.com/actions/?q=setup&type=&language=
+# Find Github Actions to@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"} setup@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"} tooling here:
+# - https://github.com/actions/?q=setup@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"}&type=&language=
 # - https://github.com/actions/starter-workflows/tree/main/ci
-# - https://github.com/marketplace?type=actions&query=setup
+# - https://github.com/marketplace?type=actions&query=setup@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"}
 #
 # Requires scripts:
 # - bin/test
@@ -26,11 +26,11 @@ jobs:
     runs-on: <image-name>
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - name: Checkout reposito@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"}ry
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
-      - name: Use <setup tooling>
-        uses: <action to setup tooling>
+      - name: Use <setup@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"} to@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"}oling>
+        uses: <action@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-reposito@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"}ry"} to setup@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"} tooling>@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/repos#get-a-repository"}
 
       - name: Install project dependencies
         run: <install dependencies>


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.